### PR TITLE
 Bug fixes to AnimatedVisualPlayer, and some test cleanup.

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
@@ -8,7 +8,7 @@
 #include "SharedHelpers.h"
 #include <synchapi.h>
 #include <winerror.h>
-
+#include <math.h>
 
 AnimatedVisualPlayer::AnimationPlay::AnimationPlay(
     AnimatedVisualPlayer& owner,
@@ -33,6 +33,7 @@ float AnimatedVisualPlayer::AnimationPlay::FromProgress()
     return m_fromProgress;
 }
 
+// REENTRANCE SIDE EFFECT: IsPlaying DP.
 void AnimatedVisualPlayer::AnimationPlay::Start()
 {
     MUX_ASSERT(!m_controller);
@@ -46,7 +47,7 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
         // Do not do anything after calling SetProgress()... the AnimationPlay is destructed already.
         return;
     }
-    else 
+    else
     {
         // Create an animation to drive the Progress property.
         auto compositor = m_owner.m_progressPropertySet.Compositor();
@@ -65,7 +66,7 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
             auto timeToEnd = (1 - m_fromProgress) / ((1 - m_fromProgress) + m_toProgress);
             animation.InsertKeyFrame(timeToEnd, 1, linearEasing);
             // Jump to the beginning.
-            animation.InsertKeyFrame(timeToEnd + FLT_EPSILON, 0, linearEasing);
+            animation.InsertKeyFrame(::nextafterf(timeToEnd, 0), 0, linearEasing);
         }
 
         // Play to toProgress
@@ -113,26 +114,27 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
         {
             // Subscribe to the batch completed event.
             m_batchCompletedToken = m_batch.Completed([this](winrt::IInspectable const&, winrt::CompositionBatchCompletedEventArgs const&)
-            {
-                // Complete the play when the batch completes.
-                //
-                // The "this" pointer is guaranteed to be valid because:
-                // 1) The AnimationPlay (*this) is kept alive by a reference from m_owner.m_nowPlaying that
-                //    is only reset by a call to the AnimationPlay::Complete() method.
-                // 2) Before m_owner.m_nowPlaying is reset in AnimationPlay::Complete(),
-                //    the m_batch.Completed event is unsubscribed, guaranteeing that this lambda
-                //    will not run after AnimationPlay::Complete() has been called.
-                // 3) To handle AnimatedVisualPlayer shutdown, AnimationPlay::Complete() is called when
-                //    the AnimatedVisualPlayer is unloaded, so that the AnimationPlay cannot outlive
-                //    the AnimatedVisualPlayer.
-                //
-                // Do not do anything after calling Complete()... the object is destructed already.
-                this->Complete();
-            });
+                {
+                    // Complete the play when the batch completes.
+                    //
+                    // The "this" pointer is guaranteed to be valid because:
+                    // 1) The AnimationPlay (*this) is kept alive by a reference from m_owner.m_nowPlaying that
+                    //    is only reset by a call to the AnimationPlay::Complete() method.
+                    // 2) Before m_owner.m_nowPlaying is reset in AnimationPlay::Complete(),
+                    //    the m_batch.Completed event is unsubscribed, guaranteeing that this lambda
+                    //    will not run after AnimationPlay::Complete() has been called.
+                    // 3) To handle AnimatedVisualPlayer shutdown, AnimationPlay::Complete() is called when
+                    //    the AnimatedVisualPlayer is unloaded, so that the AnimationPlay cannot outlive
+                    //    the AnimatedVisualPlayer.
+                    //
+                    // Do not do anything after calling Complete()... the object is destructed already.
+                    this->Complete();
+                });
             // Indicate that nothing else is going into the batch.
             m_batch.End();
         }
 
+        // WARNING - this may cause reentrance.
         m_owner.IsPlaying(true);
     }
 }
@@ -216,23 +218,29 @@ void AnimatedVisualPlayer::AnimationPlay::Resume()
 }
 
 // Completes the play, and unregisters it from the player.
-// Do not do anything with this object after calling Complete()... the object is destructed already.
+// Called on the UI thread from:
+//  * AnimatedVisualPlayer::SetProgress(...)
+//   - when any property is set that invalidates the current play, such as starting a new play or setting progress.
+//  * CompositionScopedBatch::BatchCompleted event
+//   - when a non-looping animation gets to it final keyframe.
+// Do not do anything with this object after calling here... the object is destructed already.
+// REENTRANCE SIDE EFFECT: IsPlaying DP.
 void AnimatedVisualPlayer::AnimationPlay::Complete()
 {
     //
     // NOTEs about lifetime (i.e. why we can trust that m_owner is still valid)
-    //  The AnimatedVisualPlayer will always outlive the AnimationPlay. This
+    //  The AnimatedVisualPlayer will be alive as the time when Complete() is called. This
     //  is because:
     //  1. There is only ever one un-completed AnimationPlay. When a new play
     //     is started the current play is completed.
     //  2. An uncompleted AnimationPlay will be completed when the AnimatedVisualPlayer
-    //     is unloaded.
-    //  3. Completion as a result of a call to SetProgress is always synchronous and is
-    //     called from the AnimatedVisualPlayer.
-    //  4. If the batch completion event fires, the AnimatedVisualPlayer must still be
-    //     alive because if it had been unloaded Complete() would have been called
-    //     during the unload which would have unsubscribed from the batch completion
-    //     event.
+    //     is unloaded or the AnimatedVisualPlayer destructor is run.
+    //  3. If the call to here is from AnimatedVisualPlayer::SetProgress(...)
+    //     then the AnimatedVisualPlayer is obviously still alive.
+    //  4. If the batch completion event fires the AnimatedVisualPlayer must still be
+    //     alive because if it had been unloaded or destroyedComplete() would have been
+    //     called during the unload or from the destructor which would have unsubscribed
+    //     from the batch completion event.
     //    
 
     // Grab a copy of the pointer so the object stays alive until
@@ -250,15 +258,18 @@ void AnimatedVisualPlayer::AnimationPlay::Complete()
     // disassociate it from the player and update the player's IsPlaying property.
     if (IsCurrentPlay())
     {
-        // Disconnect from the player.
+        // Disconnect this AnimationPlay from the player.
         m_owner.m_nowPlaying.reset();
 
         // Update the IsPlaying state. Note that this is done
-        // after disconnected so that we won't be reentered.
+        // after being disconnected so that this AnimationPlay won't be
+        // reentered, however the AnimatedVisualPlayer may be reentered.
+        // WARNING - this may cause reentrance.
         m_owner.IsPlaying(false);
     }
 
-    // Allow the play to complete.
+    // Allow anything waiting on this awaitable to complete.
+    // This will not cause reentrance because this signals an event and does not call out.
     CompleteAwaits();
 }
 
@@ -282,7 +293,7 @@ AnimatedVisualPlayer::AnimatedVisualPlayer()
     // definitely not visible.
     m_suspendingRevoker = winrt::Application::Current().Suspending(winrt::auto_revoke, [weakThis{ get_weak() }](
         auto const& /*sender*/,
-        auto const& /*e*/ )
+        auto const& /*e*/)
     {
         if (auto strongThis = weakThis.get())
         {
@@ -314,7 +325,7 @@ AnimatedVisualPlayer::AnimatedVisualPlayer()
                 // Transition from invisible to visible.
                 strongThis->OnUnhiding();
             }
-            else 
+            else
             {
                 // Transition from visible to invisible.
                 strongThis->OnHiding();
@@ -330,10 +341,11 @@ AnimatedVisualPlayer::AnimatedVisualPlayer()
 
 AnimatedVisualPlayer::~AnimatedVisualPlayer()
 {
-    if (m_nowPlaying != nullptr)
-    {
-        MUX_FAIL_FAST_MSG("Owner AnimatedVisualPlayer is destroyed, current playing AnimationPlay is not empty!");
-    }
+    // Ensure any outstanding play is stopped.
+    // NOTE: Stop() can cause reentrance when clients react to DP changes, but because
+    //       we're in the destructor we know that there aren't any clients who can reach
+    //       us, so reentrance is not a concern. 
+    Stop();
 }
 
 void AnimatedVisualPlayer::OnLoaded(winrt::IInspectable const& /*sender*/, winrt::RoutedEventArgs const& /*args*/)
@@ -362,13 +374,13 @@ void AnimatedVisualPlayer::OnLoaded(winrt::IInspectable const& /*sender*/, winrt
     if (m_isUnloaded)
     {
         // Reload the content. 
-        // Only do this if the elemnent had been previously unloaded so that
+        // Only do this if the element had been previously unloaded so that the
         // first Loaded event doesn't overwrite any state that was set before
         // the event was fired.
         UpdateContent();
         m_isUnloaded = false;
     }
-} 
+}
 
 void AnimatedVisualPlayer::OnUnloaded(winrt::IInspectable const& /*sender*/, winrt::RoutedEventArgs const& /*args*/)
 {
@@ -393,12 +405,14 @@ void AnimatedVisualPlayer::OnUnhiding()
     }
 }
 
+// Public API.
 // IUIElement / IUIElementOverridesHelper
 winrt::AutomationPeer AnimatedVisualPlayer::OnCreateAutomationPeer()
 {
     return winrt::make<AnimatedVisualPlayerAutomationPeer>(*this);
 }
 
+// Public API.
 // Overrides FrameworkElement::MeasureOverride. Returns the size that is needed to display the
 // animated visual within the available size and respecting the Stretch property.
 winrt::Size AnimatedVisualPlayer::MeasureOverride(winrt::Size const& availableSize)
@@ -442,7 +456,7 @@ winrt::Size AnimatedVisualPlayer::MeasureOverride(winrt::Size const& availableSi
             auto heightScale = availableSize.Height / m_animatedVisualSize.y;
             auto measuredSize = (heightScale < widthScale)
                 ? winrt::Size{ availableSize.Width, m_animatedVisualSize.y * widthScale }
-            : winrt::Size{ m_animatedVisualSize.x * heightScale, availableSize.Height };
+                : winrt::Size{ m_animatedVisualSize.x * heightScale, availableSize.Height };
 
             // Clip the size to the available size.
             measuredSize = winrt::Size{
@@ -463,9 +477,10 @@ winrt::Size AnimatedVisualPlayer::MeasureOverride(winrt::Size const& availableSi
     auto heightScale = ((availableSize.Height == std::numeric_limits<double>::infinity()) ? FLT_MAX : availableSize.Height) / m_animatedVisualSize.y;
     return (heightScale > widthScale)
         ? winrt::Size{ availableSize.Width, m_animatedVisualSize.y * widthScale }
-        : winrt::Size{ m_animatedVisualSize.x * heightScale, availableSize.Height };
+    : winrt::Size{ m_animatedVisualSize.x * heightScale, availableSize.Height };
 }
 
+// Public API.
 // Overrides FrameworkElement::ArrangeOverride. Scales to fit the animated visual into finalSize 
 // respecting the current Stretch and returns the size actually used.
 winrt::Size AnimatedVisualPlayer::ArrangeOverride(winrt::Size const& finalSize)
@@ -557,24 +572,7 @@ winrt::Size AnimatedVisualPlayer::ArrangeOverride(winrt::Size const& finalSize)
     return finalSize;
 }
 
-winrt::DependencyProperty InitializeDp(
-    wstring_view const& propertyNameString,
-    wstring_view const& propertyTypeNameString,
-    winrt::IInspectable const& defaultValue,
-    winrt::PropertyChangedCallback const& propertyChangedCallback = nullptr)
-{
-    // There are no attached properties.
-    auto isAttached = false;
-
-    return InitializeDependencyProperty(
-        propertyNameString,
-        propertyTypeNameString,
-        winrt::name_of<winrt::AnimatedVisualPlayer>(),
-        isAttached,
-        defaultValue,
-        propertyChangedCallback);
-}
-
+// Public API.
 // Accessor for ProgressObject property.
 // NOTE: This is not a dependency property because it never changes and is not useful for binding.
 winrt::CompositionObject AnimatedVisualPlayer::ProgressObject()
@@ -582,6 +580,7 @@ winrt::CompositionObject AnimatedVisualPlayer::ProgressObject()
     return m_progressPropertySet;
 }
 
+// Public API.
 // Pauses the currently playing animated visual, or does nothing if no play is underway.
 void AnimatedVisualPlayer::Pause()
 {
@@ -596,16 +595,7 @@ void AnimatedVisualPlayer::Pause()
     }
 }
 
-// Completes the current play, if any.
-void AnimatedVisualPlayer::CompleteCurrentPlay()
-{
-    if (m_nowPlaying)
-    {
-        m_nowPlaying->Complete();
-    }
-    MUX_ASSERT(!m_nowPlaying);
-}
-
+// Public API.
 winrt::IAsyncAction AnimatedVisualPlayer::PlayAsync(double fromProgress, double toProgress, bool looped)
 {
     if (!SharedHelpers::IsRS5OrHigher())
@@ -617,7 +607,7 @@ winrt::IAsyncAction AnimatedVisualPlayer::PlayAsync(double fromProgress, double 
     auto version = ++m_playAsyncVersion;
 
     // Cause any other plays to return. 
-    // This call may cause reentrance.
+    // WARNING - this call may cause reentrance via the IsPlaying DP.
     Stop();
 
     if (version != m_playAsyncVersion)
@@ -626,7 +616,7 @@ winrt::IAsyncAction AnimatedVisualPlayer::PlayAsync(double fromProgress, double 
         co_return;
     }
 
-    CompleteCurrentPlay();
+    MUX_ASSERT(!m_nowPlaying);
 
     // Adjust for the case where there is a segment that
     // goes from [fromProgress..0] where m_fromProgress > 0. 
@@ -658,6 +648,7 @@ winrt::IAsyncAction AnimatedVisualPlayer::PlayAsync(double fromProgress, double 
     if (IsAnimatedVisualLoaded())
     {
         // There is an animated visual loaded, so start it playing.
+        // WARNING - this may cause reentrance via IsPlaying DP.
         thisPlay->Start();
     }
 
@@ -674,6 +665,7 @@ winrt::IAsyncAction AnimatedVisualPlayer::PlayAsync(double fromProgress, double 
     co_await calling_thread;
 }
 
+// Public API.
 void AnimatedVisualPlayer::Resume()
 {
     if (!SharedHelpers::IsRS5OrHigher())
@@ -687,6 +679,8 @@ void AnimatedVisualPlayer::Resume()
     }
 }
 
+// Public API.
+// REENTRANCE SIDE EFFECT: IsPlaying DP via m_nowPlaying->Complete() or InsertScalar iff m_nowPlaying.
 void AnimatedVisualPlayer::SetProgress(double progress)
 {
     if (!SharedHelpers::IsRS5OrHigher())
@@ -696,30 +690,33 @@ void AnimatedVisualPlayer::SetProgress(double progress)
 
     auto clampedProgress = std::clamp(static_cast<float>(progress), 0.0F, 1.0F);
 
-    // Setting the progress value will stop the current play. 
+    // WARNING: Reentrance via IsPlaying DP may occur from this point down to the end of the method
+    //          iff m_nowPlaying.
+
+    // Setting the Progress value will stop the current play.
     m_progressPropertySet.InsertScalar(L"Progress", static_cast<float>(clampedProgress));
 
-    // Ensure the current playing task is completed.
+    // Ensure the current PlayAsync task is completed.
+    // Note that this explicit call is necessary, even though InsertScalar
+    // will stop the current animation, because the BatchCompleted event for
+    // the animation only gets hooked up if the animation is not looped.
+    // If there was a BatchCompleted event and it already fired from setting the Progress
+    // value then Complete() is a no-op.
     if (m_nowPlaying)
     {
-        // Note that this explicit call is necessary, even though InsertScalar
-        // will stop the animation, because there will be no BatchCompleted event
-        // fired if the play was looped.
         m_nowPlaying->Complete();
     }
 }
 
+// Public API.
+// REENTRANCE SIDE EFFECT: IsPlaying DP via SetProgress(...) or InsertScalar iff m_nowPlaying.
 void AnimatedVisualPlayer::Stop()
 {
-    if (!SharedHelpers::IsRS5OrHigher())
-    {
-        return;
-    }
-
     if (m_nowPlaying)
     {
         // Stop the animation by setting the Progress value to the fromProgress of the
         // most recent play.
+        // This may cause reentrance via the IsPlaying DP.
         SetProgress(m_currentPlayFromProgress);
     }
 }
@@ -753,7 +750,8 @@ void AnimatedVisualPlayer::OnSourcePropertyChanged(
 {
     auto newSource = args.NewValue().as<winrt::IAnimatedVisualSource>();
 
-    CompleteCurrentPlay();
+    // WARNING - this may cause reentrance via the IsPlaying DP iff m_nowPlaying.
+    Stop();
 
     // Disconnect from the update notifications of the old source.
     m_dynamicAnimatedVisualInvalidatedRevoker.revoke();
@@ -788,6 +786,7 @@ void AnimatedVisualPlayer::UnloadContent()
     if (m_animatedVisualRoot)
     {
         // This will complete any current play.
+        // WARNING - this may cause reentrance via IsPlaying DP iff m_nowPlaying.
         Stop();
 
         // Remove the old animated visual (if any).
@@ -807,6 +806,8 @@ void AnimatedVisualPlayer::UnloadContent()
         // WARNING - these may cause reentrance.
         Duration(winrt::TimeSpan{ 0 });
         Diagnostics(nullptr);
+        // Set IsAnimatedVisualLoaded last as it is the property that is most likely
+        // to have user code react to its state change.
         IsAnimatedVisualLoaded(false);
     }
 }
@@ -820,15 +821,13 @@ void AnimatedVisualPlayer::UpdateContent()
     auto source = Source();
     if (!source)
     {
+        // No source set. Nothing to do.
         return;
     }
 
     winrt::IInspectable diagnostics{};
     auto animatedVisual = source.TryCreateAnimatedVisual(m_rootVisual.Compositor(), diagnostics);
     m_animatedVisual.set(animatedVisual);
-
-    // WARNING - this may cause reentrance.
-    Diagnostics(diagnostics);
 
     if (!animatedVisual)
     {
@@ -842,7 +841,11 @@ void AnimatedVisualPlayer::UpdateContent()
         }
 
         // Complete any play that was started during loading.
-        CompleteCurrentPlay();
+        // WARNING - this may cause reentrance via IsPlaying DP iff m_nowPlaying.
+        Stop();
+
+        // WARNING - this may cause reentrance.
+        Diagnostics(diagnostics);
 
         return;
     }
@@ -852,6 +855,9 @@ void AnimatedVisualPlayer::UpdateContent()
     // Empty content means the source has nothing to show yet.
     if (!animatedVisual.RootVisual() || animatedVisual.Size() == winrt::float2::zero())
     {
+        // WARNING - this may cause reentrance.
+        Diagnostics(diagnostics);
+
         return;
     }
 
@@ -867,11 +873,7 @@ void AnimatedVisualPlayer::UpdateContent()
     // Hook up the new animated visual.
     m_animatedVisualRoot = animatedVisual.RootVisual();
     m_animatedVisualSize = animatedVisual.Size();
-    m_rootVisual.Children().InsertAtTop(m_animatedVisualRoot); 
-        
-    // WARNING - this may cause reentrance
-    Duration(animatedVisual.Duration());
-    IsAnimatedVisualLoaded(true);
+    m_rootVisual.Children().InsertAtTop(m_animatedVisualRoot);
 
     // Size has changed. Tell XAML to re-measure.
     InvalidateMeasure();
@@ -888,6 +890,16 @@ void AnimatedVisualPlayer::UpdateContent()
     progressAnimation.SetReferenceParameter(L"_", m_progressPropertySet);
     m_animatedVisualRoot.Properties().StartAnimation(L"Progress", progressAnimation);
 
+    // WARNING - these may cause reentrance.
+    // Set these properties before the if (AutoPlay()) branch calls PlayAsync(...)
+    // so that the properties are updated before playing starts.
+    Duration(animatedVisual.Duration());
+    Diagnostics(diagnostics);
+    // Set IsAnimatedVisualLoaded last as it is the property that is most likely
+    // to have user code react to its state change.
+    IsAnimatedVisualLoaded(true);
+
+    // Check whether playing has been started already via reentrance from a DP handler.
     if (m_nowPlaying)
     {
         m_nowPlaying->Start();
@@ -898,6 +910,7 @@ void AnimatedVisualPlayer::UpdateContent()
         auto from = 0;
         auto to = 1;
         auto looped = true;
+        // NOTE: If !IsAnimatedVisualLoaded() then this is a no-op.
         PlayAsync(from, to, looped);
     }
 }

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
@@ -79,8 +79,6 @@ private:
         winrt::Composition::CompositionScopedBatch m_batch{ nullptr };
     };
 
-    void CompleteCurrentPlay();
-
     void OnAutoPlayPropertyChanged(winrt::DependencyPropertyChangedEventArgs const& args);
 
     void OnFallbackContentPropertyChanged(winrt::DependencyPropertyChangedEventArgs const& args);

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
@@ -15,87 +15,66 @@
     </Page.Resources>
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
-        <RelativePanel x:Name="ParentPanel">
-            <Button x:Name="PlayButton" AutomationProperties.Name="PlayButton" Click="PlayButton_Click"/>
-            <TextBox x:Name="ProgressTextBox"
-                IsEnabled="False"
-                AutomationProperties.Name="ProgressTextBox"
-                Text="None"
-                RelativePanel.Below="PlayButton"/>
-            <TextBox x:Name="IsPlayingTextBoxBeforePlaying"
-                IsEnabled="False"
-                AutomationProperties.Name="IsPlayingTextBoxBeforePlaying"
-                Text="None"
-                RelativePanel.Below="ProgressTextBox"/>
-            <TextBox x:Name="IsPlayingTextBoxBeingPlaying"
-                IsEnabled="False"
-                AutomationProperties.Name="IsPlayingTextBoxBeingPlaying"
-                Text="None"
-                RelativePanel.Below="IsPlayingTextBoxBeforePlaying"/>
-            <Button x:Name="ToZeroKeyframeAnimationPlayButton"
-                AutomationProperties.Name="ToZeroKeyframeAnimationPlayButton"
-                Click="ToZeroKeyframeAnimationPlayButton_Click"
-                RelativePanel.Below="IsPlayingTextBoxBeingPlaying"/>
-            <TextBox x:Name="ToZeroKeyframeAnimationProgressTextBox"
-                IsEnabled="False"
-                AutomationProperties.Name="ToZeroKeyframeAnimationProgressTextBox"
-                Text="None"
-                RelativePanel.Below="ToZeroKeyframeAnimationPlayButton"/>
-            <Button x:Name="FromOneKeyframeAnimationPlayButton"
-                AutomationProperties.Name="FromOneKeyframeAnimationPlayButton"
-                Click="FromOneKeyframeAnimationPlayButton_Click"
-                RelativePanel.Below="ToZeroKeyframeAnimationProgressTextBox"/>
-            <TextBox x:Name="FromOneKeyframeAnimationProgressTextBox"
-                IsEnabled="False"
-                AutomationProperties.Name="FromOneKeyframeAnimationProgressTextBox"
-                Text="None"
-                RelativePanel.Below="FromOneKeyframeAnimationPlayButton"/>
-            <Button x:Name="ReverseNegativePlaybackRateAnimationPlayButton"
-                AutomationProperties.Name="ReverseNegativePlaybackRateAnimationPlayButton"
-                Click="ReverseNegativePlaybackRateAnimationPlayButton_Click"
-                RelativePanel.Below="FromOneKeyframeAnimationProgressTextBox"/>
-            <TextBox x:Name="ReverseNegativePlaybackRateAnimationTextBox"
-                IsEnabled="False"
-                AutomationProperties.Name="ReverseNegativePlaybackRateAnimationTextBox"
-                Text="None"
-                RelativePanel.Below="ReverseNegativePlaybackRateAnimationPlayButton"/>
-            <Button x:Name="ReversePositivePlaybackRateAnimationPlayButton"
-                AutomationProperties.Name="ReversePositivePlaybackRateAnimationPlayButton"
-                Click="ReversePositivePlaybackRateAnimationPlayButton_Click"
-                RelativePanel.Below="ReverseNegativePlaybackRateAnimationTextBox"/>
-            <TextBox x:Name="ReversePositivePlaybackRateAnimationTextBox"
-                IsEnabled="False"
-                AutomationProperties.Name="ReversePositivePlaybackRateAnimationTextBox"
-                Text="None"
-                RelativePanel.Below="ReversePositivePlaybackRateAnimationPlayButton"/>
-            <TextBox x:Name="HittestingTextBox"
-                IsEnabled="False"
-                AutomationProperties.Name="HittestingTextBox"
-                Text="None"
-                RelativePanel.Below="ReversePositivePlaybackRateAnimationTextBox"/>
-            <Button x:Name="FallenBackButton"
-                AutomationProperties.Name="FallenBackButton"
-                Click="FallenBackButton_ClickAsync"
-                RelativePanel.Below="HittestingTextBox"/>
-            <TextBox x:Name="FallenBackTextBox"
-                IsEnabled="False"
-                AutomationProperties.Name="FallenBackTextBox"
-                Text="None"
-                RelativePanel.Below="FallenBackButton"/>
-            <controls:AnimatedVisualPlayer
+        <Grid.Resources>
+            <Style TargetType="TextBox">
+                <Setter Property="IsEnabled" Value="False" />
+                <Setter Property="Text" Value="None" />
+            </Style>
+            <Style TargetType="StackPanel">
+                <Setter Property="Margin" Value="12"/>
+            </Style>
+        </Grid.Resources>
+
+        <StackPanel>
+            <StackPanel>
+                <Button x:Name="PlayButton" Click="PlayButton_Click">Play forwards from 0 to 1</Button>
+                <TextBox x:Name="ProgressTextBox"/>
+                <TextBox x:Name="IsPlayingTextBoxBeforePlaying"/>
+                <TextBox x:Name="IsPlayingTextBoxBeingPlaying"/>
+            </StackPanel>
+
+            <StackPanel>
+                <Button x:Name="ToZeroKeyframeAnimationPlayButton" Click="ToZeroKeyframeAnimationPlayButton_Click">Play forwards from 0.35 to 0</Button>
+                <TextBox x:Name="ToZeroKeyframeAnimationProgressTextBox"/>
+            </StackPanel>
+
+            <StackPanel>
+                <Button x:Name="FromOneKeyframeAnimationPlayButton" Click="FromOneKeyframeAnimationPlayButton_Click">Play forwards from 1 to 0.35</Button>
+                <TextBox x:Name="FromOneKeyframeAnimationProgressTextBox" />
+            </StackPanel>
+
+            <StackPanel>
+                <Button x:Name="ReverseNegativePlaybackRateAnimationPlayButton" Click="ReverseNegativePlaybackRateAnimationPlayButton_Click">Play backwards from 1 to 0.5 then forwards from 0.5 to 1</Button>
+                <TextBox x:Name="ReverseNegativePlaybackRateAnimationTextBox"/>
+            </StackPanel>
+
+            <StackPanel>
+                <Button x:Name="ReversePositivePlaybackRateAnimationPlayButton" Click="ReversePositivePlaybackRateAnimationPlayButton_Click">Play forwards from 0 to 0.5 then backwards from 0.5 to 0</Button>
+                <TextBox x:Name="ReversePositivePlaybackRateAnimationTextBox"/>
+                <TextBox x:Name="HittestingTextBox"/>
+            </StackPanel>
+
+            <StackPanel>
+                <Button x:Name="FallenBackButton" Click="FallenBackButton_ClickAsync">Fall back</Button>
+                <TextBox x:Name="FallenBackTextBox"/>
+            </StackPanel>
+
+        </StackPanel>
+
+        <controls:AnimatedVisualPlayer
+                HorizontalAlignment="Center"
                 x:Name="Player"
                 AutomationProperties.Name="Player"
                 AutomationProperties.LabeledBy="{Binding ElementName=ProgressTextBox}"
                 RelativePanel.AlignHorizontalCenterWithPanel="True"
                 AutoPlay="False"
                 PointerMoved="Player_PointerMoved">
-                <lotties:LottieLogo/>
-                <controls:AnimatedVisualPlayer.FallbackContent>
-                    <DataTemplate>
-                        <local:FallbackGrid/>
-                    </DataTemplate>
-                </controls:AnimatedVisualPlayer.FallbackContent>
-            </controls:AnimatedVisualPlayer>
-        </RelativePanel>
+            <lotties:LottieLogo/>
+            <controls:AnimatedVisualPlayer.FallbackContent>
+                <DataTemplate>
+                    <local:FallbackGrid/>
+                </DataTemplate>
+            </controls:AnimatedVisualPlayer.FallbackContent>
+        </controls:AnimatedVisualPlayer>
     </Grid>
 </local:TestPage>

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
@@ -14,9 +14,15 @@
         <local:MyCommand x:Key="TestExecuteCommand" />
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" x:Name="PageGrid" Margin="12">
         <Grid.Resources>
             <Style TargetType="TextBox">
+                <!--
+                  The TextBoxes are used by automation tests to observe state changes on this page.
+                  We'd use TextBlocks here if we could, but they don't support automation change
+                  notifications. Setting IsEnabled=False makes the TextBox behave like a TextBlock
+                  but it supports automation change notifications.
+                -->
                 <Setter Property="IsEnabled" Value="False" />
                 <Setter Property="Text" Value="None" />
             </Style>

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using AnimatedVisualPlayerTests;
 using Microsoft.Graphics.Canvas;
@@ -12,45 +13,70 @@ using Windows.Graphics.DirectX;
 using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Tests.MUXControls.ApiTests;
 
 namespace MUXControlsTestApp
 {
-    public class FallbackGrid : Windows.UI.Xaml.Controls.Grid
+    public sealed class FallbackGrid : Grid
     {
+        internal const int RectangleWidth = 100;
+        internal const int RectangleHeight = 100;
+        internal static readonly Color RectangleColor = Colors.Red;
+        // Gets the most recently created FallbackGrid
+        internal static FallbackGrid Latest;
+
         public FallbackGrid()
         {
-            _fallbackGrid = this;
-
+            Latest = this;
+            //Background = new SolidColorBrush(Colors.Red);
+            //this.HorizontalAlignment = HorizontalAlignment.Stretch;
+            //this.VerticalAlignment = VerticalAlignment.Stretch;
             Windows.UI.Xaml.Shapes.Rectangle rect = new Windows.UI.Xaml.Shapes.Rectangle();
-            rect.MinWidth = 100;
-            rect.MinHeight = 100;
-            rect.MaxWidth = 100;
-            rect.MaxHeight = 100;
-            rect.Fill = new SolidColorBrush(Colors.Red);
+            rect.MaxWidth = rect.MinWidth = RectangleWidth;
+            rect.MaxHeight = rect.MinHeight = RectangleHeight;
+            rect.Fill = new SolidColorBrush(RectangleColor);
             Children.Add(rect);
         }
-
-        static public FallbackGrid _fallbackGrid = null;
     }
 
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     [TopLevelTestPage(Name = "AnimatedVisualPlayer", Icon = "Animations.png")]
     public sealed partial class AnimatedVisualPlayerPage : TestPage
     {
-        private Visual _visual;
-
         public AnimatedVisualPlayerPage()
         {
             this.InitializeComponent();
-
-            _visual = ElementCompositionPreview.GetElementVisual(Player);
+            SetAutomationPeerNames(this);
         }
 
-        private async void PlayButton_Click(object sender, RoutedEventArgs e)
+        // Set the AutomationPeer name to be the same as the x:Name on each FrameworkElement.
+        // This is so we don't need to set both properties on the elements in XAML.
+        void SetAutomationPeerNames(FrameworkElement root)
+        {
+            var count = VisualTreeHelper.GetChildrenCount(root);
+            for (var i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+                if (child is FrameworkElement element)
+                {
+                    // Copy the x:Name into the AutomationPeer name.
+                    var name = element.Name;
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        AutomationProperties.SetName(element, name);
+                    }
+
+                    // Recurse to get the rest of the tree.
+                    SetAutomationPeerNames(element);
+                }
+            }
+        }
+
+        // Play from 0 to 1.
+        async void PlayButton_Click(object sender, RoutedEventArgs e)
         {
             bool isPlaying = Player.IsPlaying;
             IsPlayingTextBoxBeforePlaying.Text = isPlaying.ToString();
@@ -63,78 +89,76 @@ namespace MUXControlsTestApp
             ProgressTextBox.Text = Constants.PlayingEndedText;
         }
 
-        private async void ToZeroKeyframeAnimationPlayButton_Click(object sender, RoutedEventArgs e)
+        // Play forward from 0.35 to 0.
+        async void ToZeroKeyframeAnimationPlayButton_Click(object sender, RoutedEventArgs e)
         {
             await Player.PlayAsync(0.35, 0, false);
-
             ToZeroKeyframeAnimationProgressTextBox.Text = Constants.PlayingEndedText;
         }
 
-        private async void FromOneKeyframeAnimationPlayButton_Click(object sender, RoutedEventArgs e)
+        // Play forwards from 1 to 0.35.
+        async void FromOneKeyframeAnimationPlayButton_Click(object sender, RoutedEventArgs e)
         {
             await Player.PlayAsync(1, 0.35, false);
-
             FromOneKeyframeAnimationProgressTextBox.Text = Constants.PlayingEndedText;
         }
 
-        private async void ReverseNegativePlaybackRateAnimationPlayButton_Click(object sender, RoutedEventArgs e)
+        // Play backwards from 1 to 0.5 then forwards from 0.5 to 1.
+        async void ReverseNegativePlaybackRateAnimationPlayButton_Click(object sender, RoutedEventArgs e)
         {
-            Player.PlaybackRate = 0 - Int32.Parse(Constants.OneText);
+            // Start playing backwards from 1 to 0.
+            Player.PlaybackRate = -1;
             Task task1 = Player.PlayAsync(0, 1, false).AsTask();
-            Task task2 = ReverseNegativePlaybackRateAnimationAsync();
+            // Reverse direction after half of the animation duration.
+            Task task2 = DelayForHalfAnimationDurationThenReverse();
 
             await Task.WhenAll(task1, task2);
 
-            //
-            // The player's PlayAsync returns immediately in RS4 or lower windows build.
-            // Thus, Constants.OneText is set to ...TextBox's content in order to
-            // satisfy the interaction test that uses Accessibility.
-            //
-            if (IsRS5OrHigher())
-            {
-                CompositionPropertySet progressPropertySet = (CompositionPropertySet)Player.ProgressObject;
-                float value = 0f;
-                progressPropertySet.TryGetScalar("progress", out value);
-                ReverseNegativePlaybackRateAnimationTextBox.Text = value.ToString();
-            }
-            else
-            {
-                ReverseNegativePlaybackRateAnimationTextBox.Text = Constants.OneText;
-            }
+            SetTextBoxTextToPlayerProgress(
+                ReverseNegativePlaybackRateAnimationTextBox,
+                defaultValueForPreRs5: Constants.OneText);
         }
 
-        private async void ReversePositivePlaybackRateAnimationPlayButton_Click(object sender, RoutedEventArgs e)
+        // Play forward from 0 to 0.5 then backward from 0.5 to 0.
+        async void ReversePositivePlaybackRateAnimationPlayButton_Click(object sender, RoutedEventArgs e)
         {
-            Player.PlaybackRate = Int32.Parse(Constants.OneText);
+            // Start playing forward from 0 to 1.
+            Player.PlaybackRate = 1;
             Task task1 = Player.PlayAsync(0, 1, false).AsTask();
-            Task task2 = ReversePositivePlaybackRateAnimationAsync();
+
+            // Reverse direction after half of the animation duration.
+            Task task2 = DelayForHalfAnimationDurationThenReverse();
 
             await Task.WhenAll(task1, task2);
 
-            //
+            SetTextBoxTextToPlayerProgress(
+                ReversePositivePlaybackRateAnimationTextBox,
+                defaultValueForPreRs5: Constants.ZeroText);
+        }
+
+        void SetTextBoxTextToPlayerProgress(TextBox textBox, string defaultValueForPreRs5)
+        {
             // The player's PlayAsync returns immediately in RS4 or lower windows build.
-            // Thus, Constants.ZeroText is set to ...TextBox's content in order to
-            // satisfy the interaction test that uses Accessibility.
-            //
+            // For those builds set the text box with the given default value so that the tests will pass.
             if (IsRS5OrHigher())
             {
-                CompositionPropertySet progressPropertySet = (CompositionPropertySet)Player.ProgressObject;
-                float value = 1f;
-                progressPropertySet.TryGetScalar("progress", out value);
-                ReversePositivePlaybackRateAnimationTextBox.Text = value.ToString();
+                // Read the progress value from the player.
+                var progressPropertySet = (CompositionPropertySet)Player.ProgressObject;
+                progressPropertySet.TryGetScalar("progress", out var value);
+                textBox.Text = value.ToString();
             }
             else
             {
-                ReversePositivePlaybackRateAnimationTextBox.Text = Constants.ZeroText;
+                textBox.Text = defaultValueForPreRs5;
             }
         }
-        
-        private void Player_PointerMoved(object sender, RoutedEventArgs e)
+
+        void Player_PointerMoved(object sender, RoutedEventArgs e)
         {
             HittestingTextBox.Text = Constants.PointerMovedText;
         }
-        
-        private async Task GetIsPlayingAsync()
+
+        async Task GetIsPlayingAsync()
         {
             //
             // This artificial delay of 200ms is to ensure that the player's PlayAsync
@@ -150,8 +174,7 @@ namespace MUXControlsTestApp
             if (IsRS5OrHigher())
             {
                 Player.Pause();
-                bool isPlaying = Player.IsPlaying;
-                IsPlayingTextBoxBeingPlaying.Text = isPlaying.ToString();
+                IsPlayingTextBoxBeingPlaying.Text = Player.IsPlaying.ToString();
                 Player.Resume();
             }
             else
@@ -160,56 +183,43 @@ namespace MUXControlsTestApp
             }
         }
 
-        private async Task ReverseNegativePlaybackRateAnimationAsync()
+        // Delays for half of the duration of the current play then reverses direction.
+        async Task DelayForHalfAnimationDurationThenReverse()
         {
-            int delayTimeSpan = (int)(0.5 * Player.Duration.TotalMilliseconds);
+            var delayTimeSpan = TimeSpan.FromTicks((long)(0.5 * Player.Duration.Ticks));
             await Task.Delay(delayTimeSpan);
 
+            // Pause, change direction, resume in the new direction.
             Player.Pause();
-            Player.PlaybackRate = (double)(Int32.Parse(Constants.OneText));
+            Player.PlaybackRate *= -1;
             Player.Resume();
         }
 
-        private async Task ReversePositivePlaybackRateAnimationAsync()
-        {
-            int delayTimeSpan = (int)(0.5 * Player.Duration.TotalMilliseconds);
-            await Task.Delay(delayTimeSpan);
-
-            Player.Pause();
-            Player.PlaybackRate = 0 - (double)(Int32.Parse(Constants.OneText));
-            Player.Resume();
-        }
-
-        private async void FallenBackButton_ClickAsync(Object sender, RoutedEventArgs e)
+        async void FallenBackButton_ClickAsync(object sender, RoutedEventArgs e)
         {
             // VisualCapture helper functionality is only available since RS5. Because API
-            // method GraphicsCaptureItem.CreateFromVisual is a RS5 feature.
+            // method GraphicsCaptureItem.CreateFromVisual is an RS5 feature.
             if (IsRS5OrHigher())
             {
+                // nullsource is a source that always fails. We use it to trigger the fallback behavior.
                 Player.Source = new AnimatedVisuals.nullsource();
-                CanvasBitmap canvasBitmap = await RenderVisualToBitmapAsync(_visual);
 
-                Color[] colors = canvasBitmap.GetPixelColors(0, 0, 1, 1);
-                if (colors.Length > 0 && colors[0].Equals(Colors.Red/*FallenBackContent Color*/))
-                {
-                    FallenBackTextBox.Text = Constants.TrueText;
-                }
-                else
-                {
-                    FallenBackTextBox.Text = Constants.FalseText;
-                }
+                // Scrape the pixels from the Player. There should be a red rectangle where the content would go.
+                var playerVisual = ElementCompositionPreview.GetElementVisual(Player);
+                CanvasBitmap canvasBitmap = await RenderVisualToBitmapAsync(playerVisual);
+
+                var colors = canvasBitmap.GetPixelColors();
+                var redPixelCount = colors.Where(c => c == FallbackGrid.RectangleColor).Count();
+                FallenBackTextBox.Text = redPixelCount >= FallbackGrid.RectangleHeight * FallbackGrid.RectangleWidth
+                    ? Constants.TrueText
+                    : Constants.FalseText;
             }
             else
             {
-                var parent = FallbackGrid._fallbackGrid != null ? FallbackGrid._fallbackGrid.Parent : null;
-                if (parent == Player)
-                {
-                    FallenBackTextBox.Text = Constants.TrueText;
-                }
-                else
-                {
-                    FallenBackTextBox.Text = Constants.FalseText;
-                }
+                var parent = FallbackGrid.Latest?.Parent;
+                FallenBackTextBox.Text = parent == Player
+                    ? Constants.TrueText
+                    : Constants.FalseText;
             }
         }
 
@@ -269,7 +279,7 @@ namespace MUXControlsTestApp
             return await tcs.Task;
         }
 
-        private bool IsRS5OrHigher()
+        static bool IsRS5OrHigher()
         {
             return ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7);
         }

--- a/dev/AnimatedVisualPlayer/TestUI/nullsource.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/nullsource.cs
@@ -1,35 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Numerics;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Composition;
 
 namespace AnimatedVisuals
 {
+    // An IAnimatedVisualSource that always fails to create an animated visual.
+    // Used for testing of the fallback path in AnimatedVisualPlayer.
     sealed class nullsource : IAnimatedVisualSource
     {
         public IAnimatedVisual TryCreateAnimatedVisual(Compositor compositor, out object diagnostics)
         {
             diagnostics = null;
+            // Return null to indicate failure.
             return null;
-        }
-
-        sealed class AnimatedVisual : IAnimatedVisual
-        {
-            const long c_durationTicks = 59670000;
-            ContainerVisual _root;
-
-            internal AnimatedVisual(Compositor compositor)
-            {
-                _root = null;
-            }
-
-            Visual IAnimatedVisual.RootVisual => _root;
-            TimeSpan IAnimatedVisual.Duration => TimeSpan.FromTicks(c_durationTicks);
-            Vector2 IAnimatedVisual.Size => new Vector2(375, 667);
-            void IDisposable.Dispose() => _root?.Dispose();
         }
     }
 }


### PR DESCRIPTION
    Replaces assert in AVP destructor that would fire if an animation was playing. Now we just stop the animation.
    Fixes inability to react to IsAnimatedVisualLoaded DP to start playing.
    Add more commenting to help explain reentrancy in AVP.
    Simplify the test code.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->